### PR TITLE
主要恢复Datapack和Function指令的使用

### DIFF
--- a/mint-server/minecraft-patches/features/0058-Restore-the-function-and-datapack-commands-but-the-f.patch
+++ b/mint-server/minecraft-patches/features/0058-Restore-the-function-and-datapack-commands-but-the-f.patch
@@ -1,0 +1,29 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Frish2021 <1573880184@qq.com>
+Date: Wed, 9 Jul 2025 18:19:28 +0800
+Subject: [PATCH] Restore the function and datapack commands, but the function
+ function is not fully restored
+
+
+diff --git a/net/minecraft/commands/Commands.java b/net/minecraft/commands/Commands.java
+index ad19e9e599b26dfdb53929d9410860cb1b97698c..7263ab318cd48bd088f6db9be0cf192a9363350d 100644
+--- a/net/minecraft/commands/Commands.java
++++ b/net/minecraft/commands/Commands.java
+@@ -190,7 +190,7 @@ public class Commands {
+         //CloneCommands.register(this.dispatcher, context); // Folia - region threading - TODO
+         DamageCommand.register(this.dispatcher, context);
+         //DataCommands.register(this.dispatcher); // Folia - region threading - TODO
+-        //DataPackCommand.register(this.dispatcher, context); // Folia - region threading - TODO
++        if (dev.bacteriawa.mint.config.modules.experiment.DatapackCommandConfig.enabled) DataPackCommand.register(this.dispatcher, context); // Folia - region threading - TODO
+         //DebugCommand.register(this.dispatcher); // Folia - region threading - TODO
+         DefaultGameModeCommands.register(this.dispatcher);
+         //DialogCommand.register(this.dispatcher, context); // Folia - region threading - TODO
+@@ -202,7 +202,7 @@ public class Commands {
+         FillCommand.register(this.dispatcher, context);
+         FillBiomeCommand.register(this.dispatcher, context);
+         ForceLoadCommand.register(this.dispatcher);
+-        //FunctionCommand.register(this.dispatcher); // Folia - region threading - TODO
++        if (dev.bacteriawa.mint.config.modules.experiment.DatapackCommandConfig.enabled) FunctionCommand.register(this.dispatcher); // Folia - region threading - TODO
+         GameModeCommand.register(this.dispatcher);
+         GameRuleCommand.register(this.dispatcher, context);
+         GiveCommand.register(this.dispatcher, context);

--- a/mint-server/minecraft-patches/features/0059-Fix-Commands-class-can-t-used-config-system.patch
+++ b/mint-server/minecraft-patches/features/0059-Fix-Commands-class-can-t-used-config-system.patch
@@ -1,0 +1,84 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Frish2021 <1573880184@qq.com>
+Date: Wed, 9 Jul 2025 19:51:53 +0800
+Subject: [PATCH] Fix Commands class can`t used config system.
+
+
+diff --git a/net/minecraft/server/Main.java b/net/minecraft/server/Main.java
+index fd3553bdc1c3cdbf6aa3dc00e0a4987f8eaa4fb8..4fb3d3d5cb3f016554f3b3dfde5b9355cae4b0bf 100644
+--- a/net/minecraft/server/Main.java
++++ b/net/minecraft/server/Main.java
+@@ -16,6 +16,8 @@ import java.nio.file.Paths;
+ import java.util.Optional;
+ import java.util.function.BooleanSupplier;
+ import javax.annotation.Nullable;
++
++import dev.bacteriawa.mint.config.MintConfig;
+ import joptsimple.OptionParser;
+ import joptsimple.OptionSet;
+ import joptsimple.OptionSpec;
+@@ -110,6 +112,7 @@ public class Main {
+             }
+ 
+             io.papermc.paper.plugin.PluginInitializerManager.load(optionSet); // Paper
++            MintConfig.loadConfig(); // Mint
+             Bootstrap.bootStrap();
+             Bootstrap.validate();
+             Util.startTimerHackThread();
+diff --git a/net/minecraft/server/dedicated/DedicatedServer.java b/net/minecraft/server/dedicated/DedicatedServer.java
+index 3fb73cf62f51401ea0d3241e0f9fbb6b30cf7f62..93b47367baf31c17400d56651849427e7f949c82 100644
+--- a/net/minecraft/server/dedicated/DedicatedServer.java
++++ b/net/minecraft/server/dedicated/DedicatedServer.java
+@@ -20,7 +20,13 @@ import java.util.Locale;
+ import java.util.Optional;
+ import javax.annotation.Nullable;
+ 
++import dev.bacteriawa.mint.commands.MemoryBarCommand;
++import dev.bacteriawa.mint.commands.RegionBarCommand;
++import dev.bacteriawa.mint.commands.TpsBarCommand;
+ import dev.bacteriawa.mint.config.MintConfig;
++import dev.bacteriawa.mint.functions.GlobalServerMemoryBar;
++import dev.bacteriawa.mint.functions.GlobalServerRegionBar;
++import dev.bacteriawa.mint.functions.GlobalServerTpsBar;
+ import net.minecraft.DefaultUncaughtExceptionHandler;
+ import net.minecraft.DefaultUncaughtExceptionHandlerWithName;
+ import net.minecraft.SharedConstants;
+@@ -59,6 +65,7 @@ import net.minecraft.world.level.GameType;
+ import net.minecraft.world.level.Level;
+ import net.minecraft.world.level.block.entity.SkullBlockEntity;
+ import net.minecraft.world.level.storage.LevelStorageSource;
++import org.bukkit.Bukkit;
+ import org.slf4j.Logger;
+ 
+ public class DedicatedServer extends MinecraftServer implements ServerInterface {
+@@ -173,8 +180,29 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
+         this.paperConfigurations.initializeGlobalConfiguration(this.registryAccess());
+         this.paperConfigurations.initializeWorldDefaultsConfiguration(this.registryAccess());
+         // Paper end - initialize global and world-defaults configuration
+-        MintConfig.loadConfig(); // Mint
+         MintConfig.setup(); // Mint
++
++        if (dev.bacteriawa.mint.config.modules.misc.TpsBarConfig.tpsbarEnabled){
++            GlobalServerTpsBar.init();
++            Bukkit.getCommandMap().register("tpsbar","mint",new TpsBarCommand());
++        }else{
++            GlobalServerTpsBar.cancelBarUpdateTask();
++        }
++
++        if (dev.bacteriawa.mint.config.modules.misc.MembarConfig.memoryBarEnabled){
++            GlobalServerMemoryBar.init();
++            Bukkit.getCommandMap().register("membar","mint",new MemoryBarCommand());
++        }else{
++            GlobalServerMemoryBar.cancelBarUpdateTask();
++        }
++
++        if (dev.bacteriawa.mint.config.modules.misc.RegionBarConfig.regionbarEnabled) {
++            GlobalServerRegionBar.init();
++            Bukkit.getCommandMap().register("regionbar", "mint", new RegionBarCommand());
++        } else {
++            GlobalServerRegionBar.cancelBarUpdateTask();
++        }
++
+         this.server.spark.enableEarlyIfRequested(); // Paper - spark
+         // Paper start - fix converting txt to json file; convert old users earlier after PlayerList creation but before file load/save
+         if (this.convertOldUsers()) {

--- a/mint-server/src/main/java/dev/bacteriawa/mint/config/IConfigModule.java
+++ b/mint-server/src/main/java/dev/bacteriawa/mint/config/IConfigModule.java
@@ -1,4 +1,0 @@
-package dev.bacteriawa.mint.config;
-
-public interface IConfigModule {
-}

--- a/mint-server/src/main/java/dev/bacteriawa/mint/config/modules/experiment/DatapackCommandConfig.java
+++ b/mint-server/src/main/java/dev/bacteriawa/mint/config/modules/experiment/DatapackCommandConfig.java
@@ -1,0 +1,11 @@
+package dev.bacteriawa.mint.config.modules.experiment;
+
+import dev.bacteriawa.mint.config.ConfigCategory;
+import dev.bacteriawa.mint.config.ConfigField;
+import dev.bacteriawa.mint.config.Configuration;
+
+@Configuration(name = "enable_datapack_function_command", type = ConfigCategory.experiment)
+public class DatapackCommandConfig {
+    @ConfigField
+    public static boolean enabled = false;
+}

--- a/mint-server/src/main/java/dev/bacteriawa/mint/config/modules/misc/MembarConfig.java
+++ b/mint-server/src/main/java/dev/bacteriawa/mint/config/modules/misc/MembarConfig.java
@@ -20,13 +20,4 @@ public class MembarConfig {
     public static List<String> memColors = List.of("GREEN","YELLOW","RED","PURPLE");
     @ConfigField(comment = "update_interval_ticks")
     public static int updateInterval = 15;
-
-    public static void loaded(CommentedFileConfig config){
-        if (memoryBarEnabled){
-            GlobalServerMemoryBar.init();
-            Bukkit.getCommandMap().register("membar","mint",new MemoryBarCommand());
-        }else{
-            GlobalServerMemoryBar.cancelBarUpdateTask();
-        }
-    }
 }

--- a/mint-server/src/main/java/dev/bacteriawa/mint/config/modules/misc/RegionBarConfig.java
+++ b/mint-server/src/main/java/dev/bacteriawa/mint/config/modules/misc/RegionBarConfig.java
@@ -20,14 +20,4 @@ public class RegionBarConfig {
     public static List<String> utilColors = List.of("GREEN", "YELLOW", "RED", "PURPLE");
     @ConfigField(comment = "update_interval_ticks")
     public static int updateInterval = 15;
-
-
-    public static void loaded(CommentedFileConfig config) {
-        if (regionbarEnabled) {
-            GlobalServerRegionBar.init();
-            Bukkit.getCommandMap().register("regionbar", "mint", new RegionBarCommand());
-        } else {
-            GlobalServerRegionBar.cancelBarUpdateTask();
-        }
-    }
 }

--- a/mint-server/src/main/java/dev/bacteriawa/mint/config/modules/misc/SentryConfig.java
+++ b/mint-server/src/main/java/dev/bacteriawa/mint/config/modules/misc/SentryConfig.java
@@ -4,11 +4,10 @@ import com.electronwill.nightconfig.core.file.CommentedFileConfig;
 import dev.bacteriawa.mint.config.ConfigCategory;
 import dev.bacteriawa.mint.config.ConfigField;
 import dev.bacteriawa.mint.config.Configuration;
-import dev.bacteriawa.mint.config.IConfigModule;
 import org.apache.logging.log4j.Level;
 
 @Configuration(name = "sentry", type = ConfigCategory.misc)
-public class SentryConfig implements IConfigModule {
+public class SentryConfig {
 
     @ConfigField(comment = {
             "Sentry DSN for improved error logging, leave blank to disable,",

--- a/mint-server/src/main/java/dev/bacteriawa/mint/config/modules/misc/TpsBarConfig.java
+++ b/mint-server/src/main/java/dev/bacteriawa/mint/config/modules/misc/TpsBarConfig.java
@@ -24,13 +24,4 @@ public class TpsBarConfig {
     public static List<String> chunkHotColors = List.of("GREEN","YELLOW","RED","PURPLE");
     @ConfigField(comment = "update_interval_ticks")
     public static int updateInterval = 15;
-
-    public static void loaded(CommentedFileConfig config) {
-        if (tpsbarEnabled){
-            GlobalServerTpsBar.init();
-            Bukkit.getCommandMap().register("tpsbar","mint",new TpsBarCommand());
-        }else{
-            GlobalServerTpsBar.cancelBarUpdateTask();
-        }
-    }
 }


### PR DESCRIPTION
主要修改了MintConfig与Commands的优先级，恢复Datapack和Function指令的使用，以及删除IConfigModules接口
因为MintConfig的优先级低于Commands类，所以导致Commands类无法使用MintConfig的配置，所以提高了MintConfig的
优先级于Commands上。但是主要是恢复Datapack和Function指令的适合用。