### PR TITLE
将loaded的优先级降低，并且将数据包的Function tick简单修复

### DIFF
--- a/mint-server/minecraft-patches/features/0064-The-loading-mechanism-of-the-MintConfig-loaded-api-h.patch
+++ b/mint-server/minecraft-patches/features/0064-The-loading-mechanism-of-the-MintConfig-loaded-api-h.patch
@@ -1,0 +1,40 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Frish2021 <1573880184@qq.com>
+Date: Fri, 11 Jul 2025 15:36:43 +0800
+Subject: [PATCH] The loading mechanism of the MintConfig loaded api has been
+ modified.
+
+
+diff --git a/net/minecraft/server/dedicated/DedicatedServer.java b/net/minecraft/server/dedicated/DedicatedServer.java
+index 93b47367baf31c17400d56651849427e7f949c82..8da291c8171ee453cba13fbe8fde50fbc4c4b40d 100644
+--- a/net/minecraft/server/dedicated/DedicatedServer.java
++++ b/net/minecraft/server/dedicated/DedicatedServer.java
+@@ -181,28 +181,6 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
+         this.paperConfigurations.initializeWorldDefaultsConfiguration(this.registryAccess());
+         // Paper end - initialize global and world-defaults configuration
+         MintConfig.setup(); // Mint
+-
+-        if (dev.bacteriawa.mint.config.modules.misc.TpsBarConfig.tpsbarEnabled){
+-            GlobalServerTpsBar.init();
+-            Bukkit.getCommandMap().register("tpsbar","mint",new TpsBarCommand());
+-        }else{
+-            GlobalServerTpsBar.cancelBarUpdateTask();
+-        }
+-
+-        if (dev.bacteriawa.mint.config.modules.misc.MembarConfig.memoryBarEnabled){
+-            GlobalServerMemoryBar.init();
+-            Bukkit.getCommandMap().register("membar","mint",new MemoryBarCommand());
+-        }else{
+-            GlobalServerMemoryBar.cancelBarUpdateTask();
+-        }
+-
+-        if (dev.bacteriawa.mint.config.modules.misc.RegionBarConfig.regionbarEnabled) {
+-            GlobalServerRegionBar.init();
+-            Bukkit.getCommandMap().register("regionbar", "mint", new RegionBarCommand());
+-        } else {
+-            GlobalServerRegionBar.cancelBarUpdateTask();
+-        }
+-
+         this.server.spark.enableEarlyIfRequested(); // Paper - spark
+         // Paper start - fix converting txt to json file; convert old users earlier after PlayerList creation but before file load/save
+         if (this.convertOldUsers()) {

--- a/mint-server/src/main/java/dev/bacteriawa/mint/config/MintConfig.java
+++ b/mint-server/src/main/java/dev/bacteriawa/mint/config/MintConfig.java
@@ -15,6 +15,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -23,6 +24,7 @@ public class MintConfig {
     private static final File baseConfigFolder = new File("mint");
     private static final File baseConfigFile = new File(baseConfigFolder, "mint_global.toml");
     private static final CommentedFileConfig configuration;
+    private static final Set<Class<?>> moduleClasses = new HashSet<>();
 
     static {
         if (!baseConfigFolder.exists()) {
@@ -36,6 +38,7 @@ public class MintConfig {
 
     public static void setup() {
         Bukkit.getCommandMap().register("mint", new MintCommand());
+        moduleClasses.forEach(MintConfig::loaded);
     }
 
     public static void loadConfig() {
@@ -89,7 +92,7 @@ public class MintConfig {
             throw new RuntimeException(e);
         }
 
-        loaded(moduleClass);
+        moduleClasses.add(moduleClass);
     }
 
     private static void loaded(Class<?> clazz) {

--- a/mint-server/src/main/java/dev/bacteriawa/mint/config/modules/experiment/DatapackCommandConfig.java
+++ b/mint-server/src/main/java/dev/bacteriawa/mint/config/modules/experiment/DatapackCommandConfig.java
@@ -1,5 +1,6 @@
 package dev.bacteriawa.mint.config.modules.experiment;
 
+import com.electronwill.nightconfig.core.file.CommentedFileConfig;
 import dev.bacteriawa.mint.config.ConfigCategory;
 import dev.bacteriawa.mint.config.ConfigField;
 import dev.bacteriawa.mint.config.Configuration;
@@ -8,4 +9,10 @@ import dev.bacteriawa.mint.config.Configuration;
 public class DatapackCommandConfig {
     @ConfigField
     public static boolean enabled = false;
+
+    public static void loaded(CommentedFileConfig config){
+        if (enabled){
+            me.coderfrish.tick.EmulationTickRunnable.startTick();
+        }
+    }
 }

--- a/mint-server/src/main/java/dev/bacteriawa/mint/config/modules/misc/MembarConfig.java
+++ b/mint-server/src/main/java/dev/bacteriawa/mint/config/modules/misc/MembarConfig.java
@@ -20,4 +20,14 @@ public class MembarConfig {
     public static List<String> memColors = List.of("GREEN","YELLOW","RED","PURPLE");
     @ConfigField(comment = "update_interval_ticks")
     public static int updateInterval = 15;
+
+    public static void loaded(CommentedFileConfig config){
+        if (memoryBarEnabled){
+            GlobalServerMemoryBar.init();
+            Bukkit.getCommandMap().register("membar","mint",new MemoryBarCommand());
+        }else{
+            GlobalServerMemoryBar.cancelBarUpdateTask();
+        }
+    }
+
 }

--- a/mint-server/src/main/java/dev/bacteriawa/mint/config/modules/misc/RegionBarConfig.java
+++ b/mint-server/src/main/java/dev/bacteriawa/mint/config/modules/misc/RegionBarConfig.java
@@ -20,4 +20,14 @@ public class RegionBarConfig {
     public static List<String> utilColors = List.of("GREEN", "YELLOW", "RED", "PURPLE");
     @ConfigField(comment = "update_interval_ticks")
     public static int updateInterval = 15;
+
+    public static void loaded(CommentedFileConfig config) {
+        if (regionbarEnabled) {
+            GlobalServerRegionBar.init();
+            Bukkit.getCommandMap().register("regionbar", "mint", new RegionBarCommand());
+        } else {
+            GlobalServerRegionBar.cancelBarUpdateTask();
+        }
+    }
+
 }

--- a/mint-server/src/main/java/dev/bacteriawa/mint/config/modules/misc/TpsBarConfig.java
+++ b/mint-server/src/main/java/dev/bacteriawa/mint/config/modules/misc/TpsBarConfig.java
@@ -24,4 +24,14 @@ public class TpsBarConfig {
     public static List<String> chunkHotColors = List.of("GREEN","YELLOW","RED","PURPLE");
     @ConfigField(comment = "update_interval_ticks")
     public static int updateInterval = 15;
+
+    public static void loaded(CommentedFileConfig config) {
+        if (tpsbarEnabled){
+            GlobalServerTpsBar.init();
+            Bukkit.getCommandMap().register("tpsbar","mint",new TpsBarCommand());
+        }else{
+            GlobalServerTpsBar.cancelBarUpdateTask();
+        }
+    }
+
 }

--- a/mint-server/src/main/java/me/coderfrish/tick/EmulationTickRunnable.java
+++ b/mint-server/src/main/java/me/coderfrish/tick/EmulationTickRunnable.java
@@ -1,0 +1,28 @@
+package me.coderfrish.tick;
+
+import dev.bacteriawa.mint.utils.NullPlugin;
+import net.minecraft.server.MinecraftServer;
+import org.bukkit.Bukkit;
+
+public class EmulationTickRunnable implements Runnable {
+    private static final NullPlugin plugin = new NullPlugin();
+    private static final int TICK_MS = 50; // 50ms = 20TPS
+
+    @Override
+    public void run() {
+        long lastTime = System.currentTimeMillis();
+        while (MinecraftServer.getServer().isRunning()) {
+            long current = System.currentTimeMillis();
+            if (current - lastTime >= TICK_MS) {
+                MinecraftServer.getServer().getFunctions().tick();
+                lastTime = current;
+            }
+        }
+    }
+
+    public static void startTick() {
+        Bukkit.getAsyncScheduler().runNow(plugin, (t) -> {
+            new EmulationTickRunnable().run();
+        });
+    }
+}


### PR DESCRIPTION
降低Loaded优先级Pr message：改的时候突然想起可以用HashSet把要加载的类放在一起，再setup调用的时候再一起调用loaded [doge]

此更新将数据包的函数tick简单修复