### PR TITLE
关闭了idea环境下启动Mint服务器端jline输出警告日志

### DIFF
--- a/mint-server/paper-patches/features/0001-Rebrand-to-Mint.patch
+++ b/mint-server/paper-patches/features/0001-Rebrand-to-Mint.patch
@@ -393,6 +393,21 @@ index 10a0be7a4db1a51579d113d279af7a9effe7f438..d3d3d6468c09b5f33ac98f6938b849d4
      }
  
      @Override
+diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
+index 9d4d97fcb0f3cc94e9a263c61cc0e7e58fd322c3..d991e093937dc38136163aadf0e0a440394f8900 100644
+--- a/src/main/java/org/bukkit/craftbukkit/Main.java
++++ b/src/main/java/org/bukkit/craftbukkit/Main.java
+@@ -19,6 +19,10 @@ public class Main {
+     // Paper start - Reset loggers after shutdown
+     static {
+         System.setProperty("java.util.logging.manager", "io.papermc.paper.log.CustomLogManager");
++
++        if (System.console() == null) {
++            System.setProperty(net.minecrell.terminalconsole.TerminalConsoleAppender.JLINE_OVERRIDE_PROPERTY, "false");
++        }
+     }
+     // Paper end - Reset loggers after shutdown
+ 
 diff --git a/src/main/resources/logo.png b/src/main/resources/logo.png
 index c06126b92e36566c93b901637926703bbfcc42ff..44d99dcf3a89a26de61950c063ccaa3b13f17ca7 100644
 GIT binary patch


### PR DESCRIPTION
修复前jline会在最前面输出一行警告

```
[01:53:59 INFO]: [PluginInitializerManager] Initializing plugins...
[01:53:59 INFO]: [PluginInitializerManager] Initialized 0 plugins
2026-02-24T17:53:58.542213100Z main WARN Advanced terminal features are not available in this environment
[01:54:04 INFO]: Environment: Environment[sessionHost=https://sessionserver.mojang.com, servicesHost=https://api.minecraftservices.com, profilesHost=https://api.mojang.com, name=PROD]
```

主要意思是此环境下无法启用高级终端特性，造成警告的原因主要是idea的运行终端主要是模拟的，此时System.console() 获取是null 它并非是系统终端，然而jline包括适配log4j2的包装库是默认使用系统终端的，从而导致这行报错。此补丁是判断System.console() 是否为空，如果为空的话就禁用jline改受限模式的终端输入，没什么问题，能够正常输入指令。

当然，此更新是可选性， 因为只有我的电脑会出现这类问题 ：）